### PR TITLE
jupyter_server_terminals 0.5.3 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,3 +71,4 @@ about:
 extra:
   recipe-maintainers:
     - conda-forge/jupyter_server
+


### PR DESCRIPTION
jupyter_server_terminals 0.5.3 

**Destination channel:** Defaults

### Links

- [PKG-7295]
- dev_url:        https://github.com/jupyter-server/jupyter_server_terminals/tree/v0.5.3
- conda_forge:    https://github.com/conda-forge/jupyter_server_terminals-feedstock
- pypi:           https://pypi.org/project/jupyter_server_terminals/0.5.3
- pypi inspector: https://inspector.pypi.io/project/jupyter_server_terminals/0.5.3

### Explanation of changes:

- re-merging cause last one failed due to some instability on CI machines


[PKG-7295]: https://anaconda.atlassian.net/browse/PKG-7295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ