### PR TITLE
PKG-11961: jupyter_server_terminals 0.5.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyter_server_terminals" %}
-{% set version = "0.5.3" %}
+{% set version = "0.5.4" %}
 # there is a test dependency on jupyter_server, but jupyter_server has
 # a runtime dependency on this package. Build first with true, then
 # after jupyter_server is available bump build number and rebuild with false.
@@ -11,10 +11,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5ae0295167220e9ace0edcfdb212afd2b01ee8d179fe6f23c899590e9b8a5269
+  sha256: bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5
 
 build:
-  number: 1
+  number: 0
   skip: true # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 


### PR DESCRIPTION
jupyter_server_terminals 0.5.4

**Destination channel:** Defaults

### Links

- [PKG-12297]
- dev_url:        https://github.com/jupyter-server/jupyter_server_terminals/tree/v0.5.4
- conda_forge:    https://github.com/conda-forge/jupyter_server_terminals-feedstock
- pypi:           https://pypi.org/project/jupyter-server-terminals/0.5.4/
- pypi inspector: https://inspector.pypi.io/project/jupyter-server-terminals/0.5.4/

### Explanation of changes:

- new version number


[PKG-12297]: https://anaconda.atlassian.net/browse/PKG-11961